### PR TITLE
Fix for Issue #8

### DIFF
--- a/lib/firebase_id_token/signature.rb
+++ b/lib/firebase_id_token/signature.rb
@@ -94,7 +94,7 @@ module FirebaseIdToken
 
     def still_valid?(payload)
       payload['exp'].to_i > Time.now.to_i &&
-      payload['iat'].to_i < Time.now.to_i
+      payload['iat'].to_i <= Time.now.to_i
     end
 
     def issuer_authorized?(payload)


### PR DESCRIPTION
FirebaseIdToken::Signature.verify(token) returns nil for newly issued tokens.
An issued time of *right now* should be valid.