### PR TITLE
Bump Redis to '~> 4.0', '>= 4.0.1'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gem install firebase_id_token
 
 or in your Gemfile
 ```
-gem 'firebase_id_token', '~> 2.1.0'
+gem 'firebase_id_token', '~> 2.2.0'
 ```
 then
 ```

--- a/firebase_id_token.gemspec
+++ b/firebase_id_token.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.14.1'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0', '>= 1.0.0'
 
-  spec.add_runtime_dependency 'redis', '~> 4.0', '>= 4.0.1'
+  spec.add_runtime_dependency 'redis', '>= 3.3.3'
   spec.add_runtime_dependency 'redis-namespace', '~> 1.5', '>= 1.5.3'
   spec.add_dependency 'httparty', '~> 0.14.0'
   spec.add_runtime_dependency 'jwt', '~> 1.5', '>= 1.5.6'

--- a/firebase_id_token.gemspec
+++ b/firebase_id_token.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.14.1'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0', '>= 1.0.0'
 
-  spec.add_runtime_dependency 'redis', '~> 3.3', '>= 3.3.3'
+  spec.add_runtime_dependency 'redis', '~> 4.0', '>= 4.0.1'
   spec.add_runtime_dependency 'redis-namespace', '~> 1.5', '>= 1.5.3'
   spec.add_dependency 'httparty', '~> 0.14.0'
   spec.add_runtime_dependency 'jwt', '~> 1.5', '>= 1.5.6'

--- a/lib/firebase_id_token/version.rb
+++ b/lib/firebase_id_token/version.rb
@@ -1,3 +1,3 @@
 module FirebaseIdToken
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
All tests passed, it seems to be ok.

Even tho Redis changed its API since the last time, I do believe there's nothing wrong with it.
It should be working well.

But would be amazing if someone else also check it by hand (in the practice).
Just let me know.

If passed a week and no one said nothing, I will merge it.
If someone say it's indeed working, I will merge it right away.

Thanks! 