### PR TITLE
Add spec dir to be able to use fixtures in own tests

### DIFF
--- a/firebase_id_token.gemspec
+++ b/firebase_id_token.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fschuindt/firebase_id_token'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/firebase_id_token.gemspec
+++ b/firebase_id_token.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4', '>= 3.4.0'


### PR DESCRIPTION
When using the gem from rubygems in a rails project and trying to use the
`FirebaseIdToken.test!` command, an error is returned where

```
No such file or directory @ rb_sysopen - /Users/myuser/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/firebase_id_token-2.3.1/spec/fixtures/files/jwt.json
```

This commit removes the rejection of the `spec` directory when packing
the gem so that it is possible to use the fixture files in our own tests