### PR TITLE
Add ability to raise errors when verifying tokens

### DIFF
--- a/lib/firebase_id_token.rb
+++ b/lib/firebase_id_token.rb
@@ -7,6 +7,7 @@ require 'firebase_id_token/version'
 require 'firebase_id_token/exceptions/no_certificates_error'
 require 'firebase_id_token/exceptions/certificates_request_error'
 require 'firebase_id_token/exceptions/certificates_ttl_error'
+require 'firebase_id_token/exceptions/certificate_not_found'
 require 'firebase_id_token/configuration'
 require 'firebase_id_token/certificates'
 require 'firebase_id_token/signature'
@@ -49,7 +50,7 @@ module FirebaseIdToken
 
   def self.configuration
     @configuration ||= Configuration.new
-  end 
+  end
 
   # Resets Configuration to defaults.
   def self.reset

--- a/lib/firebase_id_token/certificates.rb
+++ b/lib/firebase_id_token/certificates.rb
@@ -111,13 +111,34 @@ module FirebaseIdToken
     #   FirebaseIdToken::Certificates.request
     #   cert = FirebaseIdToken::Certificates.find "1d6d01f4w7d54c7[...]"
     #   #=> <OpenSSL::X509::Certificate: subject=#<OpenSSL [...]
-    def self.find(kid)
+    def self.find(kid, raise_error: false)
       certs = new.local_certs
       raise Exceptions::NoCertificatesError if certs.empty?
 
-      if certs[kid]
-        OpenSSL::X509::Certificate.new certs[kid]
-      end
+      return OpenSSL::X509::Certificate.new certs[kid] if certs[kid]
+
+      return unless raise_error
+
+      raise Exceptions::CertificateNotFound,
+        "Unable to find a certificate with `#{kid}`."
+    end
+
+    # Returns a `OpenSSL::X509::Certificate` object of the requested Key ID
+    # (KID) if there's one.
+    #
+    # @raise {Exceptions::CertificateNotFound} if it cannot be found.
+    #
+    # @raise {Exceptions::NoCertificatesError} if the Redis certificates
+    # database is empty.
+    #
+    # @param [String] kid Key ID
+    # @return [OpenSSL::X509::Certificate]
+    # @example
+    #   FirebaseIdToken::Certificates.request
+    #   cert = FirebaseIdToken::Certificates.find! "1d6d01f4w7d54c7[...]"
+    #   #=> <OpenSSL::X509::Certificate: subject=#<OpenSSL [...]
+    def self.find!(kid)
+      find(kid, raise_error: true)
     end
 
     # Returns the current certificates TTL (Time-To-Live) in seconds. *Zero

--- a/lib/firebase_id_token/exceptions/certificate_not_found.rb
+++ b/lib/firebase_id_token/exceptions/certificate_not_found.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module FirebaseIdToken
+  module Exceptions
+    # @see FirebaseIdToken::Certificates.find!
+    class CertificateNotFound < StandardError; end
+  end
+end

--- a/lib/firebase_id_token/testing/certificates.rb
+++ b/lib/firebase_id_token/testing/certificates.rb
@@ -12,10 +12,10 @@ module FirebaseIdToken
     # + {Certificates.private_key}
     # + {Certificates.certificate}
     class Certificates
-      # `.find` is stabbed to always return the same certificate.
+      # `.find` is stubbed to always return the same certificate.
       # @param [String] kid Key ID
       # @return [nil, OpenSSL::X509::Certificate]
-      def self.find(kid)
+      def self.find(kid, raise_error: false)
         cert = certificate
         OpenSSL::X509::Certificate.new cert
       end

--- a/spec/firebase_id_token/certificates_spec.rb
+++ b/spec/firebase_id_token/certificates_spec.rb
@@ -128,6 +128,28 @@ module FirebaseIdToken
       end
     end
 
+    describe '.find!' do
+      context 'without certificates in Redis database' do
+        it 'raises a exception' do
+          expect{ described_class.find!(kid)}.
+            to raise_error(Exceptions::NoCertificatesError)
+        end
+      end
+      context 'with certificates in Redis database' do
+        it 'returns a OpenSSL::X509::Certificate when it finds the kid' do
+          described_class.request
+          expect(described_class.find!(kid)).to be_a(OpenSSL::X509::Certificate)
+        end
+
+        it 'raises a CertificateNotFound error when it can not find the kid' do
+          described_class.request
+          expect { described_class.find!('') }
+            .to raise_error(Exceptions::CertificateNotFound, /Unable to find/)
+        end
+      end
+
+    end
+
     describe '.ttl' do
       it 'returns a positive number when has certificates in Redis' do
         described_class.request

--- a/spec/firebase_id_token/signature_spec.rb
+++ b/spec/firebase_id_token/signature_spec.rb
@@ -3,11 +3,14 @@ require 'spec_helper'
 module FirebaseIdToken
   describe Signature do
     let(:jwt) { JSON.parse File.read('spec/fixtures/files/jwt.json') }
+    let(:raise_certificates_error) { false }
 
-    let (:mock_certificates) {
-      allow(Certificates).to receive(:find).with(an_instance_of(String)) {
-        OpenSSL::X509::Certificate.new(jwt['certificate']) }
-    }
+    let(:mock_certificates) do
+      allow(Certificates)
+        .to(receive(:find))
+        .with(an_instance_of(String), raise_error: raise_certificates_error)
+        .and_return(OpenSSL::X509::Certificate.new(jwt['certificate']))
+    end
 
     before :each do
       mock_certificates
@@ -27,6 +30,23 @@ module FirebaseIdToken
 
       it 'returns nil with a invalid key format' do
         expect(described_class.verify('aaa')).to be(nil)
+      end
+    end
+
+    describe '#verify!' do
+      let(:raise_certificates_error) { true }
+      it 'returns a Hash when the signature is valid' do
+        expect(described_class.verify!(jwt['jwt_token'])).to be_a(Hash)
+      end
+
+      it 'raises an error when the signature is invalid' do
+        expect { described_class.verify!(jwt['bad_jwt_token']) }
+          .to raise_error(JWT::VerificationError)
+      end
+
+      it 'raises an error with a invalid key format' do
+        expect { described_class.verify!('aaa') }
+          .to raise_error(JWT::DecodeError, /too many/)
       end
     end
   end


### PR DESCRIPTION
My team is struggling with a sparodic issue and having trouble debugging exactly where things are going wrong. This pull requests adds the abililty to selectively raise errors during `Signature.verify`.

New methods and one exception added.  Added tests as well.

```ruby
FirebaseIdToken::Certificates.find!
FirebaseIdToken::Signatures.verify!
FirebaseIdToken::Exceptions::CertificateNotFound
```

Also can do so selectively based on the environment, for example:

```ruby
  FirebaseIdToken::Signature
    .verify(token, raise_error: Rails.env.development?)
```

If there are any changes you would like me to make, including to documentation, am more than happy to include them.

This is to assist in efforts debugging an issue we are having where sparodically the development server will suddenly be unable to decode a token even while the rails console can! The problem can only be resolved by restarting the machine the server is running on.  It is strange that the console would work while the server will not (and restarting the server does not help).