### PR TITLE
Caching certificates on memory.

### DIFF
--- a/lib/firebase_id_token/signature.rb
+++ b/lib/firebase_id_token/signature.rb
@@ -78,7 +78,20 @@ module FirebaseIdToken
 
     # @see Signature.verify
     def verify
-      certificate = firebase_id_token_certificates.find(@kid, raise_error: @raise_error)
+      var_name = :_firebase_id_token_cert
+      Thread.current[var_name] ||= {
+        cert: nil,
+        expires_at: Time.now.utc - 1
+      }
+
+      if Thread.current[var_name][:expires_at] <= Time.now.utc
+        Thread.current[var_name] = {
+          cert: firebase_id_token_certificates.find(@kid, raise_error: @raise_error),
+          expires_at: Time.now.utc + firebase_id_token_certificates.ttl
+        }
+      end
+
+      certificate = Thread.current[var_name][:cert]
       return unless certificate
 
       payload = decode_jwt_payload(@jwt_token, certificate.public_key)

--- a/lib/firebase_id_token/testing/certificates.rb
+++ b/lib/firebase_id_token/testing/certificates.rb
@@ -80,6 +80,10 @@ module FirebaseIdToken
           )
         )
       end
+
+      def self.ttl
+        10
+      end
     end
   end
 end

--- a/lib/firebase_id_token/version.rb
+++ b/lib/firebase_id_token/version.rb
@@ -1,3 +1,3 @@
 module FirebaseIdToken
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
 end

--- a/lib/firebase_id_token/version.rb
+++ b/lib/firebase_id_token/version.rb
@@ -1,3 +1,3 @@
 module FirebaseIdToken
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 end


### PR DESCRIPTION
**The problem:** 
For every` FirebaseIdToken::Signature.verify` it initiates `FirebaseIdToken::Certificates ` instance and on the initialize level it calls `read_certificates` method which retrieves certificate from Redis for each call. This is leading to unnecessary Redis call. 

**The problem:** 
I have refactored `FirebaseIdToken::Signature.verify` which utilize  Thread variables to cache certificates and ttl. With this new setup, there will only one Redis call with the life of ttl. No extra J`SON.parse` and no extra certificate generation with `OpenSSL::X509::Certificate.new`