### PR TITLE
Use Time.current instead Time.now to woks with timezones

### DIFF
--- a/lib/firebase_id_token/signature.rb
+++ b/lib/firebase_id_token/signature.rb
@@ -117,8 +117,8 @@ module FirebaseIdToken
     end
 
     def still_valid?(payload)
-      payload['exp'].to_i > Time.now.to_i &&
-      payload['iat'].to_i <= Time.now.to_i
+      payload['exp'].to_i > Time.current.to_i &&
+      payload['iat'].to_i <= Time.current.to_i
     end
 
     def issuer_authorized?(payload)


### PR DESCRIPTION
This step of validation is not working when the server are in a diferente timezone.
There are also a discussion that recommends to not use Time.now and use Time.current instead.
https://discuss.rubyonrails.org/t/time-now-vs-time-current-vs-datetime-now/75183